### PR TITLE
feat(qr): custom component for no permission

### DIFF
--- a/demo/components/NoPermissionComponent.tsx
+++ b/demo/components/NoPermissionComponent.tsx
@@ -1,0 +1,12 @@
+import { View, Text } from 'react-native'
+import React from 'react'
+
+const NoPermissionComponent = () => {
+  return (
+    <View>
+      <Text>Some custom text</Text>
+    </View>
+  )
+}
+
+export default NoPermissionComponent

--- a/demo/components/NoPermissionComponent.tsx
+++ b/demo/components/NoPermissionComponent.tsx
@@ -9,4 +9,4 @@ const NoPermissionComponent = () => {
   )
 }
 
-export default NoPermissionComponent
+export default NoPermissionComponent;

--- a/demo/components/expo-qr-scanner.stories.tsx
+++ b/demo/components/expo-qr-scanner.stories.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import NoPermissionComponent from './NoPermissionComponent'
 import { ComponentStory, ComponentMeta } from '@storybook/react-native'
 import { QrScanner } from '@aries-components/expo-qr-scanner'
 import { action } from '@storybook/addon-actions'
@@ -15,6 +16,7 @@ const QrScannerMeta: ComponentMeta<typeof QrScanner> = {
     headerStyle: {
       description: 'Style of the headerText',
     },
+    renderNoPermission: { description: "Custom Component to display when permission is not granted" },
   },
   args: {
     basic: {
@@ -28,6 +30,7 @@ const QrScannerMeta: ComponentMeta<typeof QrScanner> = {
       cancelStyle: { color: 'blue', fontSize: 20 },
       headerText: 'Custom header text',
       headerStyle: { color: 'pink', fontSize: 25 },
+      renderNoPermission: NoPermissionComponent,
     },
   },
 }

--- a/packages/expo-qr-scanner/src/components/Camera.tsx
+++ b/packages/expo-qr-scanner/src/components/Camera.tsx
@@ -4,9 +4,12 @@ import { Platform, StyleProp, ViewStyle } from 'react-native'
 
 import { Camera as ExpoCamera, PermissionStatus } from 'expo-camera'
 import React, { forwardRef, useRef } from 'react'
-import { Text, Dimensions, StyleSheet } from 'react-native'
+import { Text, Dimensions, StyleSheet, View } from 'react-native'
 
-export const Camera = forwardRef<ExpoCamera, PropsWithChildren<ExpoCameraProps>>((props, ref) => {
+type ExtendedExpoCameraProps = ExpoCameraProps & { renderNoPermission?: () => React.ReactNode }
+
+export const Camera = forwardRef<ExpoCamera, PropsWithChildren<ExtendedExpoCameraProps>>((props, ref) => {
+  const { renderNoPermission = () => <Text>No permissions granted</Text> } = props;
   const [permissionResponse] = ExpoCamera.useCameraPermissions({
     get: true,
     request: true,
@@ -20,7 +23,7 @@ export const Camera = forwardRef<ExpoCamera, PropsWithChildren<ExpoCameraProps>>
   }
 
   if (permissionResponse.status !== PermissionStatus.GRANTED) {
-    return <Text>No permissions granted</Text>
+    return <View>{renderNoPermission()}</View>;
   }
 
   // Android has issues with aspect ratio

--- a/packages/expo-qr-scanner/src/components/QrScanner.tsx
+++ b/packages/expo-qr-scanner/src/components/QrScanner.tsx
@@ -15,6 +15,7 @@ type QrScannerOptions = {
   headerText?: string
   headerStyle?: StyleProp<TextStyle>
   cancelStyle?: StyleProp<TextStyle>
+  renderNoPermission?: () => React.ReactNode
 }
 
 /**
@@ -30,6 +31,7 @@ type QrScannerOptions = {
  * @param headerText - Text displayed at the top of the QrScanner
  * @param cancelStyle - Custom styling for the text inside the cancel button
  * @param headerStyle - Custom styling for the header text
+ * @param renderNoPermission - Custom Component to display when permission is not granted
  *
  */
 export const QrScanner: React.FunctionComponent<QrScannerOptions> = ({
@@ -39,6 +41,7 @@ export const QrScanner: React.FunctionComponent<QrScannerOptions> = ({
   headerText,
   cancelStyle,
   headerStyle,
+  renderNoPermission,
 }) => {
   const onBarCodeScanned = async ({ data }: BarCodeScanningResult) => {
     // get the read string
@@ -60,7 +63,7 @@ export const QrScanner: React.FunctionComponent<QrScannerOptions> = ({
   }
 
   return (
-    <Camera onBarCodeScanned={onBarCodeScanned}>
+    <Camera onBarCodeScanned={onBarCodeScanned} renderNoPermission={renderNoPermission}>
       {/* We ignore as `BarcodeMask is not seen as a valid component, type-wise.
           This is however not the case and works like how it is supposed to. */}
       {/* @ts-ignore */}


### PR DESCRIPTION
Allow package consumers to use a custom component when permission has not been granted to the application.

Use Case:
developers might want to prompt the user to change their settings using e.g: `Linking.openURL('app-settings:');`